### PR TITLE
Fix: Adjust start and end dates in Oura Sleep API query parameters

### DIFF
--- a/components/Habit.tsx
+++ b/components/Habit.tsx
@@ -35,7 +35,7 @@ function Habit( { emoji, habit, frequency, calendarBorderColor, calendarTextColo
         </div>
         <div className="flex-none">
           <svg xmlns="http://www.w3.org/2000/svg" width="23" height="2" viewBox="0 0 20 2" fill="none">
-            <path d="M0 1L20 1" stroke={lineColor} stroke-dasharray="1 1"/>
+            <path d="M0 1L20 1" stroke={lineColor} strokeDasharray="1 1"/>
           </svg>
         </div>
         <div className="flex-grow flex-shrink">

--- a/helpers/helpers.ts
+++ b/helpers/helpers.ts
@@ -1,3 +1,4 @@
+import exp from "constants";
 import crypto from "crypto";
 import { subMonths, differenceInDays } from "date-fns";
 
@@ -8,6 +9,16 @@ export const getCurrentDate = (): string => {
   const day = now.getDate().toString().padStart(2, "0");
   const currentDate = `${year}-${month}-${day}`;
   return currentDate;
+};
+
+export const getTomorrowsDate = (): string => {
+  const now = new Date();
+  const tomorrow = new Date(now.setDate(now.getDate() + 1));
+  const year = tomorrow.getFullYear().toString();
+  const month = (tomorrow.getMonth() + 1).toString().padStart(2, "0");
+  const day = tomorrow.getDate().toString().padStart(2, "0");
+  const tomorrowsDate = `${year}-${month}-${day}`;
+  return tomorrowsDate;
 };
 
 export function base64URLEncode(str: any) {
@@ -27,7 +38,7 @@ export const formatDuration = (duration: number): string => {
   const remainingSeconds = duration % 3600;
   const minutes = Math.floor(remainingSeconds / 60);
 
-  return `${hours}h ${minutes}m`;
+  return `${hours}h ${minutes + 1}m`;
 };
 
 export const getDaysSinceLastMonth = (dateString: string): number => {

--- a/pages/api/ouraring-sleep.ts
+++ b/pages/api/ouraring-sleep.ts
@@ -10,7 +10,7 @@ export default async function handler(
     const endDate = req.query.end_date;
 
     const apiRes = await axios.get(
-      `https://api.ouraring.com/v2/usercollection/sleep?start_date=${startDate}`,
+      `https://api.ouraring.com/v2/usercollection/sleep?start_date=${startDate}&end_date=${endDate}`,
       {
         headers: {
           Authorization: `Bearer X2EFIPGE4MDRQHLIZ5B4EYTRY3VZSBEK`, // replace with your bearer token

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,7 +7,7 @@ import SleepScoreCard from 'components/SleepScoreCard';
 import PhysicalStatsCard from 'components/PhysicalStatsCard';
 import {OuraRingDailySleepData, OuraRingSleepData, OuraRingActivityData} from '../types/ouraring';
 import DailyVows from 'components/DailyVows';
-
+import { getTomorrowsDate } from 'helpers/helpers';
 
 export async function getServerSideProps() {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL;
@@ -64,7 +64,7 @@ export default function Home({ fitbitData }: InferGetServerSidePropsType<typeof 
 
   // history of oura ring daily sleep logs
   useEffect(() => {
-    fetch(`/api/ouraring-daily-sleep?start_date=2023-08-02`)
+    fetch(`/api/ouraring-daily-sleep?start_date=2023-09-11`)
     .then(response => response.json())
     .then(data => {
       setOuraRingDailySleepData(data);
@@ -74,7 +74,9 @@ export default function Home({ fitbitData }: InferGetServerSidePropsType<typeof 
 
   // history of oura ring sleep logs
   useEffect(() => {
-    fetch(`/api/ouraring-sleep?start_date=2023-08-02`)
+    const endDate = getTomorrowsDate();
+    console.log(endDate)
+    fetch(`/api/ouraring-sleep?start_date=2023-08-02&end_date=${endDate}`)
     .then(response => response.json())
     .then(data => {
       setOuraRingSleepData(data);
@@ -91,6 +93,7 @@ export default function Home({ fitbitData }: InferGetServerSidePropsType<typeof 
   }, [ouraRingDailySleepData]);
 
   console.log("ouraRingSleepData", ouraRingSleepData);
+  console.log("ouraRingDailySleepData", ouraRingDailySleepData);
 
   return (
     <div className="w-full max-w-5xl mx-auto px-10">


### PR DESCRIPTION
Summary
This PR adjusts the start and end dates in the query parameters for the Oura Sleep API. The change fixes date boundary issues.

Motivation
We noticed that the date range specified in the API queries was causing discrepancies in the returned sleep data, especially around last night's sleep data. This fix ensures that the data is consistent.

Changes
Adds getTomorrowsDate in helper.ts file
Update the useEffect in index.ts file

