### PR TITLE
Feature: Initialize New Week for Habits and Update UI State

### DIFF
--- a/lib/databaseOps.ts
+++ b/lib/databaseOps.ts
@@ -61,3 +61,23 @@ export const getHabitsStreakData = async () => {
 
   return streakData;
 };
+
+export const createNewWeekEntry = async (
+  habitName: string,
+  startMonday: string
+) => {
+  const { data, error } = await supabase.from("weekly_habits").insert([
+    {
+      habit_name: habitName,
+      start_monday_of_week: startMonday,
+      checked_days: Array(7).fill(false),
+    },
+  ]);
+
+  if (error) {
+    console.error("Error creating new week entry:", error);
+    return null;
+  }
+
+  return data;
+};


### PR DESCRIPTION
Overview
This PR introduces the functionality to initialize a new week for each habit in the weekly_habits table. It also updates the UI state to reflect these changes.

Changes
Added initializeWeek function to fetch or create weekly habit data.
Added createNewWeekEntry function to initialize a new week for each habit in the database.
Updated setCurrentWeek to set the UI state based on the latest week data.
